### PR TITLE
Update code in conformance with LEGO brand guidelines.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,10 @@
 Package: lego
 Type: Package
-Title: Lego set data 1970-2015
+Title: LEGO set data for 1970-2015
 Version: 0.2
 Date: 2015-09-06
 Authors@R: 'Sean Kross <smk240@gmail.com> [aut,cre]'
-Description: Data for every lego set produced from 1970 to 2015 including number
+Description: Data for every LEGO set produced from 1970 to 2015 including number
     of pieces per set, number of minifigures per set, and region specific MSRP.
 Depends:
     R (>= 3.1.0)

--- a/R/data.R
+++ b/R/data.R
@@ -1,11 +1,11 @@
-#' Lego set data
+#' LEGO set data
 #'
-#' Data about every lego set from 1970 to 2014.
+#' Data about every LEGO set from 1970 to 2014.
 #'
 #' @source \url{http://brickset.com/}, downloaded 2014-08-06
 #' @format A data frame with columns:
 #' \describe{
-#'  \item{Item_Number}{Item number for each lego set}
+#'  \item{Item_Number}{Item number for each LEGO set}
 #'  \item{Name}{Name of set}
 #'  \item{Year}{Year set was manufactured}
 #'  \item{Theme}{Theme of set}

--- a/R/lego.R
+++ b/R/lego.R
@@ -1,6 +1,6 @@
-#' @title Lego set data 1970-2015
+#' @title LEGO set data 1970-2015
 #' @name lego
-#' @description Data for every lego set produced from 1970 to 2015 including number
+#' @description Data for every LEGO set produced from 1970 to 2015 including number
 #' of pieces per set, number of minifigures per set, and region specific MSRP.
 #' 
 #' @seealso \code{\link{legosets}}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lego
 
-This R data package contains information about every Lego set manufactured from 1970 to 2015, a total of 6172 sets. A few of the variables included for each set are:
+This R data package contains information about every LEGO set manufactured from 1970 to 2015, a total of 6172 sets. A few of the variables included for each set are:
 
 - Item number
 - Name

--- a/man/lego.Rd
+++ b/man/lego.Rd
@@ -4,9 +4,9 @@
 \name{lego}
 \alias{lego}
 \alias{lego-package}
-\title{Lego set data 1970-2015}
+\title{LEGO set data 1970-2015}
 \description{
-Data for every lego set produced from 1970 to 2015 including number
+Data for every LEGO set produced from 1970 to 2015 including number
 of pieces per set, number of minifigures per set, and region specific MSRP.
 }
 \seealso{

--- a/man/legosets.Rd
+++ b/man/legosets.Rd
@@ -3,10 +3,10 @@
 \docType{data}
 \name{legosets}
 \alias{legosets}
-\title{Lego set data}
+\title{LEGO set data}
 \format{A data frame with columns:
 \describe{
- \item{Item_Number}{Item number for each lego set}
+ \item{Item_Number}{Item number for each LEGO set}
  \item{Name}{Name of set}
  \item{Year}{Year set was manufactured}
  \item{Theme}{Theme of set}
@@ -32,7 +32,7 @@
 legosets
 }
 \description{
-Data about every lego set from 1970 to 2014.
+Data about every LEGO set from 1970 to 2014.
 }
 \examples{
 legosets


### PR DESCRIPTION
I have realized that in many places LEGO has been spelled lowercase as in _lego_.  This is against the LEGO brand guidelines which can be found here: [https://bricks.stackexchange.com/a/8659](https://bricks.stackexchange.com/a/8659)

I have tried to update all the files, but if there are some that I have missed please let me know!!